### PR TITLE
Add feature to auto-archive Amazon GC orders if requested

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ _site/
 # Files on maintainer's machine
 .DS_Store
 .idea/
+.vscode/
 .editorconfig
 notes.txt
 

--- a/src/debbit.py
+++ b/src/debbit.py
@@ -724,6 +724,7 @@ class Merchant:
         self.spread_min_gap = merchant_config.get('advanced', {}).get('spread', {}).get('min_gap', 14400)  # 4 hours
         self.spread_time_variance = merchant_config.get('advanced', {}).get('spread', {}).get('time_variance', 14400)  # 4 hours
         self.dry_run = merchant_config.get('dry_run', False)
+        self.merchant_specific_config = merchant_config['merchant_specific_config']
 
 
 class Config:

--- a/src/debbit.py
+++ b/src/debbit.py
@@ -111,8 +111,13 @@ def burst_loop(merchant):
             LOGGER.info('Now bursting ' + str(this_burst_count) + ' ' + merchant.id + ' ' + plural('purchase', this_burst_count))
 
             result = web_automation_wrapper(merchant)  # First execution outside of loop so we don't sleep before first execution and don't sleep after last execution
+            if (result == Result.dry_run):
+                LOGGER.info('Dry run completed - no payment was submitted.')
+                break
+
             cur_purchase_count += 1
-            for i in range(this_burst_count - 1):
+
+            for _ in range(this_burst_count - 1):
                 if result != Result.success:
                     break
                 sleep_time = merchant.burst_intra_gap
@@ -718,6 +723,7 @@ class Merchant:
         self.burst_poll_gap = merchant_config.get('advanced', {}).get('burst', {}).get('poll_gap', 300)  # 5 minutes
         self.spread_min_gap = merchant_config.get('advanced', {}).get('spread', {}).get('min_gap', 14400)  # 4 hours
         self.spread_time_variance = merchant_config.get('advanced', {}).get('spread', {}).get('time_variance', 14400)  # 4 hours
+        self.dry_run = merchant_config.get('dry_run', False)
 
 
 class Config:

--- a/src/program_files/merchants/amazon_gift_card_reload.py
+++ b/src/program_files/merchants/amazon_gift_card_reload.py
@@ -229,11 +229,37 @@ def web_automation(driver, merchant, amount):
         return Result.unverified
 
     if driver.find_elements_by_xpath("//*[contains(text(), 'your order has been placed') or contains(text(),'Order placed')]"):
+        if merchant.merchant_specific_config['archive'] == True:
+            best_effort_archive_order(driver)
+
         return Result.success
     else:
         LOGGER.error('Clicked "Place your order" button, but unable to confirm if order was successful.')
         return Result.unverified
 
+# Best-effort archive the most recent GC reload if we're asked to
+def best_effort_archive_order(driver):
+    amazon_consistency_delay_sec = 8
+
+    LOGGER.info(
+        f'Waiting {amazon_consistency_delay_sec} seconds before attempting to archive last reload')
+    time.sleep(amazon_consistency_delay_sec)
+
+    driver.get('https://smile.amazon.com/gp/your-account/order-history/')
+
+    first_archive_link_xpath = "(//a[contains(text(),'Amazon Reload')]/../../../../../../../../../../..//a[contains(text(),'Archive order')])"
+
+    try:
+        WebDriverWait(driver, 10).until(expected_conditions.element_to_be_clickable((By.XPATH, first_archive_link_xpath)))
+        driver.find_element_by_xpath(first_archive_link_xpath).click()
+
+        archive_popup_link_xpath = "//input[@value='archiveOrder']"
+        WebDriverWait(driver, 10).until(expected_conditions.element_to_be_clickable((By.XPATH, archive_popup_link_xpath)))
+        driver.find_element_by_xpath(archive_popup_link_xpath).click()
+
+        LOGGER.info('Archived reload successfully.')
+    except TimeoutException:
+        LOGGER.warning("Couldn't find a reload to archive. Continuing.")
 
 def handle_anti_automation_challenge(driver, merchant):
     try:

--- a/src/program_files/merchants/amazon_gift_card_reload.py
+++ b/src/program_files/merchants/amazon_gift_card_reload.py
@@ -212,6 +212,9 @@ def web_automation(driver, merchant, amount):
     if not is_order_total_correct(driver, amount):
         return Result.unverified
 
+    if merchant.dry_run == True:
+      return Result.dry_run
+
     if driver.find_elements_by_id('submitOrderButtonId'):
         time.sleep(1 + random.random() * 2)
         driver.find_element_by_id('submitOrderButtonId').click()  # Click "Place your order" button

--- a/src/program_files/merchants/example_merchant.py
+++ b/src/program_files/merchants/example_merchant.py
@@ -57,6 +57,10 @@ def web_automation(driver, merchant, amount):
     time.sleep(2)  # pause to let user watch what's happening - not necessary for real merchants
     driver.find_element_by_id('amount').send_keys(utils.cents_to_str(amount))
     time.sleep(2)  # pause to let user watch what's happening - not necessary for real merchants
+
+    if merchant.dry_run == True:
+        return Result.dry_run
+
     driver.find_element_by_id('submit-payment').click()
 
     try:

--- a/src/program_files/merchants/optimum_bill_pay.py
+++ b/src/program_files/merchants/optimum_bill_pay.py
@@ -54,6 +54,9 @@ def web_automation(driver, merchant, amount):
     button_str = driver.find_element_by_id('otpSubmit').get_attribute('value')
     expect_str = "Pay $" + utils.cents_to_str(amount) + " now with " + merchant.card
 
+    if merchant.dry_run == True:
+        return Result.dry_run
+
     if button_str == expect_str:
         driver.find_element_by_id('otpSubmit').click()
         LOGGER.info('Submitting purchase: ' + button_str)

--- a/src/program_files/merchants/xfinity_bill_pay.py
+++ b/src/program_files/merchants/xfinity_bill_pay.py
@@ -69,6 +69,10 @@ Detected first time run captcha. Please follow these one-time steps. Future runs
 
     WebDriverWait(driver, 5).until(expected_conditions.presence_of_element_located((By.XPATH, "//button[contains(text(),'Submit Payment')]")))
     time.sleep(random.random() * 3)
+
+    if merchant.dry_run == True:
+        return Result.dry_run
+
     driver.find_element_by_xpath("//button[contains(text(),'Submit Payment')]").click()
 
     try:

--- a/src/result.py
+++ b/src/result.py
@@ -6,3 +6,4 @@ class Result(Enum):
     skipped = 'skipped',  # try again 24 hours later, do not notify user
     unverified = 'unverified',  # do not try again, notify user of error
     failed = 'failed'  # retry up to 5 times, if still failing then notify user of error after final failure
+    dry_run = 'dry_run'  # successfully completed a test run without actually submitting a charge

--- a/src/sample_config.txt
+++ b/src/sample_config.txt
@@ -16,3 +16,4 @@ example_card_description:
     psw: pass
     card: 2222
     burst_count: 2
+    dry_run: False

--- a/src/sample_config.txt
+++ b/src/sample_config.txt
@@ -16,4 +16,7 @@ example_card_description:
     psw: pass
     card: 2222
     burst_count: 2
+    merchant_specific_config:
+        # Set to true to automatically archive the latest gift card reload, currently only supported on Amazon
+        archive: True
     dry_run: False


### PR DESCRIPTION
A lot of Amazon GC reloads pollutes my order history, which is annoying. Amazon has a feature where you can "Archive" up to 500 orders, which will remove them from the default view. I thought people who are using this might find it helpful - I know I did.

The other change I made to support this was enabling a concept of a "dry run" that does everything except hitting the "submit" button.

I know you mentioned you were refactoring some of this so feel free to ask me to postpone or rebase after whatever changes you're making to config, etc are done.