### PR TITLE
fix $ syntax to prevent everything between dollar signs from rendering as math

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Debbit is a set it and forget it solution to automate monthly transaction count 
 
 * [Prevent credit card closures from inactivity](https://www.doctorofcredit.com/which-banks-close-credit-cards-for-inactivity/) - Banks will close out credit cards due to inactivity. Use Debbit to automatically schedule 1 tiny transaction per month for all your sock drawer credit cards.
 
-* [Get $.99 per card per month for free](https://www.doctorofcredit.com/small-balance-waiver-a-k-a-lots-of-free-99-cent-amazon-gcs/) - Many (most?) banks will waive your credit card bill if your balance is less than $1. Use Debbit to schedule one $.99 Amazon gift card reload per month for all your sock drawer credit cards.
+* [Get $.99 per card per month for free](https://www.doctorofcredit.com/small-balance-waiver-a-k-a-lots-of-free-99-cent-amazon-gcs/) - Many (most?) banks will waive your credit card bill if your balance is less than $1. Use Debbit to schedule one $0.99 Amazon gift card reload per month for all your sock drawer credit cards.
 
 ### Debbit currently supports
 - Amazon gift card reloads (confirmed working as of Dec. 18th 2021)


### PR DESCRIPTION

See: https://github.blog/changelog/2022-05-19-render-mathematical-expressions-in-markdown/

Small PR, but otherwise it was rendering incorrectly due to the new math feature.

![image](https://user-images.githubusercontent.com/19912012/176918637-f0a569fa-0149-422c-b305-9be1f24e79df.png)

Sometimes it even doesn't render at all

![image](https://user-images.githubusercontent.com/19912012/176919909-fab45e67-b5f7-49ea-bf1f-a1f13784da9c.png)
